### PR TITLE
Context variables: Allow users to inject a dictionary of context vari…

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,25 @@ View all the columns & their data types as well as individual details of each co
 |float|![](https://raw.githubusercontent.com/aschonfeld/dtale-media/master/images/Describe_float.png)||
 
 #### Filter
-Apply a simple pandas `query` to your data (link to pandas documentation included in popup)
+Apply a simple pandas `query` to your data (link to pandas documentation included in popup)  
+
+Context Variables are user-defined values passed in via the `context_variables` argument to dtale.show(); they can be referenced in filters by prefixing the variable name with '@'.
+
+For example, here is how you can use context variables in a pandas query:
+```python
+import pandas as pd
+
+df = pd.DataFrame([
+  dict(name='Joe', age=7),
+  dict(name='Bob', age=23),
+  dict(name='Ann', age=45),
+  dict(name='Cat', age=88),
+])
+two_oldest_ages = df['age'].nlargest(2)
+df.query('age in @two_oldest_ages')
+```
+And here is how you would pass that context variable to D-Tale: `dtale.show(df, context_variables=dict(two_oldest_ages=two_oldest_ages))`
+
 
 |Editing|Result|
 |--------|:------:|

--- a/dtale/app.py
+++ b/dtale/app.py
@@ -394,7 +394,7 @@ def find_free_port():
 
 
 def show(data=None, host=None, port=None, name=None, debug=False, subprocess=True, data_loader=None,
-         reaper_on=True, open_browser=False, notebook=False, force=False, **kwargs):
+         reaper_on=True, open_browser=False, notebook=False, force=False, context_vars=None, **kwargs):
     """
     Entry point for kicking off D-Tale :class:`flask:flask.Flask` process from python process
 
@@ -423,6 +423,9 @@ def show(data=None, host=None, port=None, name=None, debug=False, subprocess=Tru
     :param force: if true, this will force the D-Tale instance to run on the specified host/port by killing any
                   other process running at that location
     :type force: bool, optional
+    :param context_vars: a dictionary of the variables that will be available for use in user-defined expressions,
+                         such as filters
+    :type context_vars: dict, optional
 
     :Example:
 
@@ -440,7 +443,7 @@ def show(data=None, host=None, port=None, name=None, debug=False, subprocess=Tru
 
     initialize_process_props(host, port, force)
     url = build_url(ACTIVE_PORT, ACTIVE_HOST)
-    instance = startup(url, data=data, data_loader=data_loader, name=name)
+    instance = startup(url, data=data, data_loader=data_loader, name=name, context_vars=context_vars)
     is_active = not running_with_flask_debug() and is_up(url)
     if is_active:
         def _start():

--- a/dtale/dash_application/charts.py
+++ b/dtale/dash_application/charts.py
@@ -21,7 +21,7 @@ from dtale.dash_application.layout import (AGGS, build_error,
 from dtale.utils import (classify_type, dict_merge, divide_chunks,
                          flatten_lists, get_dtypes, make_list,
                          make_timeout_request, run_query)
-from dtale.views import DATA
+from dtale.views import DATA, CONTEXT_VARIABLES
 from dtale.views import build_chart as build_chart_data
 
 
@@ -720,7 +720,7 @@ def build_figure_data(data_id, chart_type=None, query=None, x=None, y=None, z=No
                                   rolling_comp=rolling_comp)):
             return None
 
-        data = run_query(DATA[data_id], query)
+        data = run_query(DATA[data_id], query, CONTEXT_VARIABLES[data_id])
         chart_kwargs = dict(group_col=group, agg=agg, allow_duplicates=chart_type == 'scatter', rolling_win=window,
                             rolling_comp=rolling_comp)
         if chart_type in ZAXIS_CHARTS:

--- a/dtale/dash_application/views.py
+++ b/dtale/dash_application/views.py
@@ -17,7 +17,7 @@ from dtale.dash_application.layout import (bar_input_style, base_layout,
                                            show_input_handler,
                                            show_yaxis_ranges)
 from dtale.utils import dict_merge, make_list, run_query
-from dtale.views import DATA
+from dtale.views import DATA, CONTEXT_VARIABLES
 
 logger = getLogger(__name__)
 
@@ -139,7 +139,7 @@ def init_callbacks(dash_app):
         :rtype: tuple of (str, str, str)
         """
         try:
-            run_query(DATA[get_data_id(pathname)], query)
+            run_query(DATA[get_data_id(pathname)], query, CONTEXT_VARIABLES[get_data_id(pathname)])
             return query, {'line-height': 'inherit'}, ''
         except BaseException as ex:
             return curr_query, {'line-height': 'inherit', 'background-color': 'pink'}, str(ex)

--- a/static/__tests__/dtale/DataViewer-filter-test.jsx
+++ b/static/__tests__/dtale/DataViewer-filter-test.jsx
@@ -201,4 +201,43 @@ describe("DataViewer tests", () => {
       }, 400);
     }, 400);
   });
+
+  test("DataViewer: filtering, context variables error", done => {
+    const { DataViewer } = require("../../dtale/DataViewer");
+    const Filter = require("../../dtale/Filter").default;
+    const ContextVariables = require("../../dtale/ContextVariables").default;
+
+    const store = reduxUtils.createDtaleStore();
+    buildInnerHTML({ settings: "", dataId: "error" }, store);
+    const result = mount(
+      <Provider store={store}>
+        <DataViewer />
+      </Provider>,
+      {
+        attachTo: document.getElementById("content"),
+      }
+    );
+
+    setTimeout(() => {
+      result.update();
+
+      //open filter
+      clickMainMenuButton(result, "Filter");
+      result.update();
+      setTimeout(() => {
+        result.update();
+        t.equal(
+          result
+            .find(Filter)
+            .find(ContextVariables)
+            .find(RemovableError)
+            .find("div.dtale-alert")
+            .text(),
+          "Error loading context variables",
+          "should display error"
+        );
+        done();
+      }, 400);
+    }, 400);
+  });
 });

--- a/static/__tests__/redux-test-utils.jsx
+++ b/static/__tests__/redux-test-utils.jsx
@@ -121,6 +121,22 @@ const PROCESSES = [
     columns: 3,
   },
 ];
+
+const CONTEXT_VARIABLES = {
+  context_variables: {
+    foo: "bar",
+    cat: "dog",
+  },
+  success: true,
+};
+
+function getDataId(url) {
+  if (_.startsWith(url, "/dtale/context-variables")) {
+    return url.split("?")[0].split("/")[3];
+  }
+  return null;
+}
+
 // eslint-disable-next-line max-statements, complexity
 function urlFetcher(url) {
   const urlParams = qs.parse(url.split("?")[1]);
@@ -188,6 +204,8 @@ function urlFetcher(url) {
       return { error: "error test" };
     }
     return { success: true };
+  } else if (_.startsWith(url, "/dtale/context-variables")) {
+    return getDataId(url) === "error" ? { error: "Error loading context variables" } : CONTEXT_VARIABLES;
   }
   return {};
 }

--- a/static/dtale/ContextVariables.css
+++ b/static/dtale/ContextVariables.css
@@ -1,0 +1,16 @@
+.contextVariables .cell,
+.contextVariables .headerCell {
+    width: 100%;
+    height: 100%;
+    display: inline-block;
+    border-width: 1px;
+    border-style: solid;
+    border-color: rgba(170, 170, 170, 0.25);
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.contextVariables .headerCell {
+    font-weight: bold;
+}

--- a/static/dtale/ContextVariables.jsx
+++ b/static/dtale/ContextVariables.jsx
@@ -1,0 +1,112 @@
+import _ from "lodash";
+import PropTypes from "prop-types";
+import React from "react";
+import { fetchJson } from "../fetcher";
+import { Bouncer } from "../Bouncer";
+import { RemovableError } from "../RemovableError";
+import AutoSizer from "react-virtualized/dist/commonjs/AutoSizer";
+import Column from "react-virtualized/dist/commonjs/Table/Column";
+import Table from "react-virtualized/dist/commonjs/Table/Table";
+import { ROW_HEIGHT } from "../dtale/gridUtils";
+
+require("./ContextVariables.css");
+
+const displayName = "Context Variables";
+
+const propTypes = {
+  dataId: PropTypes.string.isRequired,
+};
+
+class ContextVariables extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      error: null,
+      loading: false,
+      contextVars: [],
+    };
+    this.renderInfoForUser = this.renderInfoForUser.bind(this);
+    this.renderTable = this.renderTable.bind(this);
+  }
+
+  componentDidMount() {
+    this.setState({ loading: true });
+    fetchJson(`/dtale/context-variables/${this.props.dataId}`, contextVarsData => {
+      if (contextVarsData.error) {
+        this.setState({
+          error: <RemovableError {...contextVarsData} />,
+          loading: false,
+          contextVars: [],
+        });
+      } else {
+        this.setState({
+          error: null,
+          loading: false,
+          contextVars: _.map(contextVarsData.context_variables, (v, k) => ({ name: k, value: v })),
+        });
+      }
+    });
+  }
+
+  renderInfoForUser() {
+    return (
+      <div>
+        <h3>Context Variables</h3>
+        <p>
+          These are initialized via the <var>context_vars</var> argument to dtale.show(), ex:
+          <span className="font-weight-bold"> dtale.show(df, context_vars={"{'foo': [1, 2, 3]}"})</span>
+          <br />
+          They can be referenced in filters by prefixing the variable name with {"'@'"}, ex:
+          <span className="font-weight-bold"> Col in @foo </span>to only show rows where {"'Col'"} is in list {"'foo'"}
+        </p>
+      </div>
+    );
+  }
+
+  renderTable() {
+    if (this.state.loading) {
+      return <Bouncer />;
+    }
+    if (this.state.error) {
+      return <div>{this.state.error}</div>;
+    }
+    if (this.state.contextVars.length === 0) {
+      return <p>No context variables are defined.</p>;
+    }
+    return (
+      <div>
+        <AutoSizer disableHeight>
+          {({ width }) => (
+            <Table
+              className="contextVariables"
+              width={width}
+              height={Math.min(300, (this.state.contextVars.length + 1) * (ROW_HEIGHT + 2))}
+              headerHeight={ROW_HEIGHT}
+              headerClassName="headerCell"
+              rowHeight={ROW_HEIGHT}
+              rowCount={this.state.contextVars.length}
+              rowGetter={({ index }) => this.state.contextVars[index]}
+              rowStyle={{ display: "flex" }}>
+              <Column label="Name" dataKey="name" width={200} className="cell" />
+              <Column label="Value" dataKey="value" width={300} flexGrow={1} className="cell" />
+            </Table>
+          )}
+        </AutoSizer>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div className="container mt-5 w-100">
+        {this.renderInfoForUser()}
+        {this.renderTable()}
+      </div>
+    );
+  }
+}
+
+ContextVariables.displayName = displayName;
+ContextVariables.propTypes = propTypes;
+
+export default ContextVariables;

--- a/static/dtale/Filter.jsx
+++ b/static/dtale/Filter.jsx
@@ -6,6 +6,7 @@ import { Modal, ModalBody, ModalClose, ModalFooter, ModalHeader, ModalTitle } fr
 import { RemovableError } from "../RemovableError";
 import { buildURLString } from "../actions/url-utils";
 import { fetchJson } from "../fetcher";
+import ContextVariables from "./ContextVariables";
 
 class Filter extends React.Component {
   constructor(props) {
@@ -102,6 +103,9 @@ class Filter extends React.Component {
                 </li>
               </ul>
             </div>
+          </div>
+          <div className="row">
+            <ContextVariables dataId={this.props.dataId} />
           </div>
         </ModalBody>
         <ModalFooter>

--- a/tests/dtale/test_utils.py
+++ b/tests/dtale/test_utils.py
@@ -108,7 +108,7 @@ def test_filter_df_for_grid(test_data):
             'baz': {'type': 'StringFilter', 'value': 'baz'}
         })
     })
-    results = utils.filter_df_for_grid(test_data, utils.retrieve_grid_params(req))
+    results = utils.filter_df_for_grid(test_data, utils.retrieve_grid_params(req), dict())
     pdt.assert_frame_equal(results, test_data[test_data.security_id == 1])
 
     req = build_req_tuple({
@@ -118,7 +118,7 @@ def test_filter_df_for_grid(test_data):
             'baz': {'type': 'StringFilter', 'value': '=baz'}
         })
     })
-    results = utils.filter_df_for_grid(test_data, utils.retrieve_grid_params(req))
+    results = utils.filter_df_for_grid(test_data, utils.retrieve_grid_params(req), dict())
     pdt.assert_frame_equal(results, test_data[test_data.security_id == 1])
 
     req = build_req_tuple({
@@ -128,11 +128,11 @@ def test_filter_df_for_grid(test_data):
             'date': {'type': 'StringFilter', 'value': '2000-01-01'}
         })
     })
-    results = utils.filter_df_for_grid(test_data, utils.retrieve_grid_params(req))
+    results = utils.filter_df_for_grid(test_data, utils.retrieve_grid_params(req), dict())
     pdt.assert_frame_equal(results, test_data[test_data.security_id == 1])
 
     req = build_req_tuple({'query': 'security_id == 1'})
-    results = utils.filter_df_for_grid(test_data, utils.retrieve_grid_params(req))
+    results = utils.filter_df_for_grid(test_data, utils.retrieve_grid_params(req), dict())
     pdt.assert_frame_equal(results, test_data[test_data.security_id == 1])
 
     req = build_req_tuple({'page': 1, 'page_size': 50})


### PR DESCRIPTION
…ables upon starting a dtale process.

These variables can be referenced in query strings by prefixing the name with @.
This can simplify complex queries immensely.