### PR TITLE
fix missing semicolon in dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         "plotly>=4.9.0",
         "ppscore; python_version >= '3.6'",
         "requests",
-        "scikit-learn >= '0.21.0'",
+        "scikit-learn; >= '0.21.0'",
         "scipy",
         "squarify",
         "statsmodels==0.10.2; python_version < '3.0'",


### PR DESCRIPTION
The string-based listings of dependences in setup.py seem very error prone.  Please consider if a different method to list deps(requirements.txt or pyproject.toml) would be better.  The current missing semicolon breaks environment exports in conda and produces a warning in poetry.