### PR TITLE
Add option to 'pin' the menu to the screen as a fixed side panel

### DIFF
--- a/dtale/static/css/main.css
+++ b/dtale/static/css/main.css
@@ -8747,6 +8747,16 @@ caption {
   text-align: center;
 }
 
+.pinned-data-viewer-menu {
+  top: 100%;
+  -webkit-box-shadow: 0 0 0 1px rgba(101, 108, 126, 0.5) inset, 0 1px 3px 1px rgba(64, 64, 64, 0.2);
+  box-shadow: 0 0 0 1px rgba(101, 108, 126, 0.5) inset, 0 1px 3px 1px rgba(64, 64, 64, 0.2);
+  background: #ebedee;
+  min-width: 15em;
+  color: #404040;
+  font-weight: 400;
+}
+
 .column-toggle__dropdown {
   position: absolute;
   top: 100%;
@@ -8794,20 +8804,23 @@ caption {
   border-left: 0.5em solid transparent;
 }
 
-.column-toggle__dropdown header {
+.column-toggle__dropdown header,
+.pinned-data-viewer-menu header {
   border-bottom: solid 1px #a7b3b7;
   padding: .3em .5em;
   color: #565b68;
   font-weight: 600;
 }
 
-.column-toggle__dropdown ul {
+.column-toggle__dropdown ul,
+.pinned-data-viewer-menu ul {
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
-.column-toggle__dropdown li {
+.column-toggle__dropdown li,
+.pinned-data-viewer-menu li {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
@@ -8815,23 +8828,27 @@ caption {
   width: 100%;
 }
 
-.column-toggle__dropdown ul.col-menu-descriptors {
+.column-toggle__dropdown ul.col-menu-descriptors,
+.pinned-data-viewer-menu ul.col-menu-descriptors {
   list-style: disc;
   padding-left: 1.5em;
   font-weight: normal;
 }
 
-.column-toggle__dropdown ul.col-menu-descriptors li {
+.column-toggle__dropdown ul.col-menu-descriptors li,
+.pinned-data-viewer-menu ul.col-menu-descriptors li {
   border-bottom: 0;
   display: list-item;
 }
 
-.column-toggle__dropdown ul.col-menu-descriptors li span {
+.column-toggle__dropdown ul.col-menu-descriptors li span,
+.pinned-data-viewer-menu ul.col-menu-descriptors li span {
   padding-left: 0.25em;
   font-weight: bold;
 }
 
-.column-toggle__dropdown li span {
+.column-toggle__dropdown li span,
+.pinned-data-viewer-menu li span {
   padding: .3em;
 }
 

--- a/dtale/static/css/main.css
+++ b/dtale/static/css/main.css
@@ -8752,6 +8752,7 @@ caption {
   -webkit-box-shadow: 0 0 0 1px rgba(101, 108, 126, 0.5) inset, 0 1px 3px 1px rgba(64, 64, 64, 0.2);
   box-shadow: 0 0 0 1px rgba(101, 108, 126, 0.5) inset, 0 1px 3px 1px rgba(64, 64, 64, 0.2);
   background: #ebedee;
+  height: fit-content;
   min-width: 15em;
   color: #404040;
   font-weight: 400;

--- a/dtale/static/css/main.css
+++ b/dtale/static/css/main.css
@@ -8753,7 +8753,7 @@ caption {
   box-shadow: 0 0 0 1px rgba(101, 108, 126, 0.5) inset, 0 1px 3px 1px rgba(64, 64, 64, 0.2);
   background: #ebedee;
   height: fit-content;
-  min-width: 15em;
+  min-width: 14em;
   color: #404040;
   font-weight: 400;
 }

--- a/static/__tests__/dtale/DataViewer-base-test.jsx
+++ b/static/__tests__/dtale/DataViewer-base-test.jsx
@@ -64,7 +64,7 @@ describe("DataViewer tests", () => {
         ["Duplicates", "Correlations", "Predictive Power Score", "Charts", "Network Viewer", "Heat Map"],
         ["Highlight Dtypes", "Highlight Missing", "Highlight Outliers", "Highlight Range", "Low Variance Flag"],
         ["Instances 1", "Code Export", "Export", "Load Data", "Refresh Widths", "About", "Theme", "Reload Data"],
-        ["Shutdown"]
+        ["Pin menu", "Shutdown"]
       )
     );
     await tick();

--- a/static/__tests__/dtale/menu/XArrayOption-test.jsx
+++ b/static/__tests__/dtale/menu/XArrayOption-test.jsx
@@ -1,16 +1,29 @@
 import { mount } from "enzyme";
 import _ from "lodash";
 import React from "react";
+import { Provider } from "react-redux";
 
 import { describe, expect, it } from "@jest/globals";
 
+import { MenuTooltip } from "../../../dtale/menu/MenuTooltip";
 import { ReactXArrayOption as XArrayOption } from "../../../dtale/menu/XArrayOption";
+import reduxUtils from "../../redux-test-utils";
+import { buildInnerHTML } from "../../test-utils";
 
 describe("XArrayOption tests", () => {
   it("renders selected xarray dimensions", () => {
-    const result = mount(<XArrayOption xarray={true} xarrayDim={{ foo: 1 }} />, {
-      attachTo: document.getElementById("content"),
-    });
+    const store = reduxUtils.createDtaleStore();
+    buildInnerHTML({ settings: "" }, store);
+    const result = mount(
+      <Provider store={store}>
+        <XArrayOption xarray={true} xarrayDim={{ foo: 1 }} />,
+        <MenuTooltip />,
+      </Provider>,
+      {
+        attachTo: document.getElementById("content"),
+      }
+    );
+    result.find("li").simulate("mouseover");
     expect(_.endsWith(result.find("div.hoverable__content").text(), "1 (foo)")).toBe(true);
   });
 });

--- a/static/__tests__/iframe/DataViewer-base-test.jsx
+++ b/static/__tests__/iframe/DataViewer-base-test.jsx
@@ -108,7 +108,7 @@ describe("DataViewer iframe tests", () => {
         ["Duplicates", "Correlations", "Predictive Power Score", "Charts", "Network Viewer", "Heat Map"],
         ["Highlight Dtypes", "Highlight Missing", "Highlight Outliers", "Highlight Range", "Low Variance Flag"],
         ["Instances 1", "Code Export", "Export", "Load Data", "Refresh Widths", "About", "Theme", "Reload Data"],
-        ["Open In New Tab", "Shutdown"]
+        ["Pin menu", "Open In New Tab", "Shutdown"]
       )
     );
   });

--- a/static/__tests__/iframe/DataViewer-within-iframe-test.jsx
+++ b/static/__tests__/iframe/DataViewer-within-iframe-test.jsx
@@ -75,7 +75,7 @@ describe("DataViewer within iframe tests", () => {
         ["Duplicates", "Correlations", "Predictive Power Score", "Charts", "Network Viewer", "Heat Map"],
         ["Highlight Dtypes", "Highlight Missing", "Highlight Outliers", "Highlight Range", "Low Variance Flag"],
         ["Instances 1", "Code Export", "Export", "Load Data", "Refresh Widths", "About", "Theme", "Reload Data"],
-        ["Open In New Tab", "Shutdown"]
+        ["Pin menu", "Open In New Tab", "Shutdown"]
       )
     );
     clickMainMenuButton(result, "Open In New Tab");

--- a/static/__tests__/reducers/dtale-test.jsx
+++ b/static/__tests__/reducers/dtale-test.jsx
@@ -32,6 +32,10 @@ describe("reducer tests", () => {
       settings: {},
       pythonVersion: null,
       isPreview: false,
+      menuPinned: false,
+      menuTooltip: {
+        visible: false,
+      },
     };
     expect(state).toEqual(store.getState());
   });

--- a/static/dtale/DataViewer.jsx
+++ b/static/dtale/DataViewer.jsx
@@ -23,7 +23,6 @@ import { ColumnMenu } from "./column/ColumnMenu";
 import { exports as gu } from "./gridUtils";
 import Descriptions from "./menu-descriptions.json";
 import { DataViewerMenu } from "./menu/DataViewerMenu";
-import { MenuTooltip } from "./menu/MenuTooltip";
 
 require("./DataViewer.css");
 const URL_PROPS = ["ids", "sortInfo"];
@@ -219,7 +218,6 @@ class ReactDataViewer extends React.Component {
     return (
       <GridEventHandler propagateState={this.propagateState} gridState={this.state}>
         <DtaleHotkeys propagateState={this.propagateState} {...this.state} />
-        <MenuTooltip />
         <DataViewerMenu {...this.state} propagateState={this.propagateState} />
         <InfiniteLoader
           isRowLoaded={({ index }) => _.has(this.state, ["data", index])}
@@ -240,7 +238,7 @@ class ReactDataViewer extends React.Component {
                       onScroll={this.props.closeColumnMenu}
                       cellRenderer={this._cellRenderer}
                       height={gridHeight}
-                      width={width - 3}
+                      width={width - (this.props.menuPinned ? 185 : 3)}
                       columnWidth={({ index }) => gu.getColWidth(index, this.state)}
                       onSectionRendered={this._onSectionRendered}
                       ref={mg => (this._grid = mg)}
@@ -281,14 +279,16 @@ ReactDataViewer.propTypes = {
   openChart: PropTypes.func,
   theme: PropTypes.string,
   updateFilteredRanges: PropTypes.func,
+  menuPinned: PropTypes.bool,
 };
 
 const ReduxDataViewer = connect(
-  ({ dataId, iframe, theme, settings }) => ({
+  ({ dataId, iframe, theme, settings, menuPinned }) => ({
     dataId,
     iframe,
     theme,
     settings,
+    menuPinned,
   }),
   dispatch => ({
     closeColumnMenu: () => dispatch(actions.closeColumnMenu()),

--- a/static/dtale/DataViewer.jsx
+++ b/static/dtale/DataViewer.jsx
@@ -23,6 +23,7 @@ import { ColumnMenu } from "./column/ColumnMenu";
 import { exports as gu } from "./gridUtils";
 import Descriptions from "./menu-descriptions.json";
 import { DataViewerMenu } from "./menu/DataViewerMenu";
+import { MenuTooltip } from "./menu/MenuTooltip";
 
 require("./DataViewer.css");
 const URL_PROPS = ["ids", "sortInfo"];
@@ -107,9 +108,8 @@ class ReactDataViewer extends React.Component {
     if (loading) {
       this.setState({ loadQueue: _.concat(loadQueue, [ids]) });
       return;
-    } else {
-      this.setState({ loading: true, ids });
     }
+    this.setState({ loading: true, ids });
     let newIds = [`${ids[0]}-${ids[1]}`];
     let savedData = {};
     if (!refresh) {
@@ -219,55 +219,54 @@ class ReactDataViewer extends React.Component {
     return (
       <GridEventHandler propagateState={this.propagateState} gridState={this.state}>
         <DtaleHotkeys propagateState={this.propagateState} {...this.state} />
-        <div style={{ display: "flex", width: "100%", height: "100%" }}>
-          <DataViewerMenu {...this.state} propagateState={this.propagateState} />
-          <InfiniteLoader
-            isRowLoaded={({ index }) => _.has(this.state, ["data", index])}
-            loadMoreRows={_.noop}
-            rowCount={this.state.rowCount}>
-            {({ onRowsRendered }) => {
-              this._onRowsRendered = onRowsRendered;
-              return (
-                <AutoSizer className="main-grid" onResize={() => this._grid.recomputeGridSize()}>
-                  {({ width, height }) => {
-                    const gridHeight = height - (gu.hasNoInfo(this.state) ? 3 : 23);
-                    return [
-                      <DataViewerInfo key={0} width={width} {...this.state} propagateState={this.propagateState} />,
-                      <MultiGrid
-                        {...this.state}
-                        key={1}
-                        columnCount={gu.getActiveCols(this.state).length}
-                        onScroll={this.props.closeColumnMenu}
-                        cellRenderer={this._cellRenderer}
-                        height={gridHeight}
-                        width={width - 3}
-                        columnWidth={({ index }) => gu.getColWidth(index, this.state)}
-                        onSectionRendered={this._onSectionRendered}
-                        ref={mg => (this._grid = mg)}
-                      />,
-                    ];
-                  }}
-                </AutoSizer>
-              );
-            }}
-          </InfiniteLoader>
-          <Popup propagateState={this.propagateState} />
-          <Formatting
-            {..._.pick(this.state, ["data", "columns", "columnFormats", "nanDisplay"])}
-            selectedCol={_.get(this.state.selectedCols, "0")}
-            visible={formattingOpen}
-            propagateState={this.propagateState}
-          />
-          <MeasureText />
-          <ColumnMenu
-            {..._.pick(this.state, ["columns", "sortInfo", "columnFilters", "outlierFilters", "error"])}
-            backgroundMode={this.state.backgroundMode}
-            propagateState={this.propagateState}
-            noInfo={gu.hasNoInfo(this.state)}
-          />
-          <div id="edit-tt" className="hoverable__content edit-cell" style={{ display: "none" }}>
-            {Descriptions.editing}
-          </div>
+        <MenuTooltip />
+        <DataViewerMenu {...this.state} propagateState={this.propagateState} />
+        <InfiniteLoader
+          isRowLoaded={({ index }) => _.has(this.state, ["data", index])}
+          loadMoreRows={_.noop}
+          rowCount={this.state.rowCount}>
+          {({ onRowsRendered }) => {
+            this._onRowsRendered = onRowsRendered;
+            return (
+              <AutoSizer className="main-grid" onResize={() => this._grid.recomputeGridSize()}>
+                {({ width, height }) => {
+                  const gridHeight = height - (gu.hasNoInfo(this.state) ? 3 : 23);
+                  return [
+                    <DataViewerInfo key={0} width={width} {...this.state} propagateState={this.propagateState} />,
+                    <MultiGrid
+                      {...this.state}
+                      key={1}
+                      columnCount={gu.getActiveCols(this.state).length}
+                      onScroll={this.props.closeColumnMenu}
+                      cellRenderer={this._cellRenderer}
+                      height={gridHeight}
+                      width={width - 3}
+                      columnWidth={({ index }) => gu.getColWidth(index, this.state)}
+                      onSectionRendered={this._onSectionRendered}
+                      ref={mg => (this._grid = mg)}
+                    />,
+                  ];
+                }}
+              </AutoSizer>
+            );
+          }}
+        </InfiniteLoader>
+        <Popup propagateState={this.propagateState} />
+        <Formatting
+          {..._.pick(this.state, ["data", "columns", "columnFormats", "nanDisplay"])}
+          selectedCol={_.get(this.state.selectedCols, "0")}
+          visible={formattingOpen}
+          propagateState={this.propagateState}
+        />
+        <MeasureText />
+        <ColumnMenu
+          {..._.pick(this.state, ["columns", "sortInfo", "columnFilters", "outlierFilters", "error"])}
+          backgroundMode={this.state.backgroundMode}
+          propagateState={this.propagateState}
+          noInfo={gu.hasNoInfo(this.state)}
+        />
+        <div id="edit-tt" className="hoverable__content edit-cell" style={{ display: "none" }}>
+          {Descriptions.editing}
         </div>
       </GridEventHandler>
     );

--- a/static/dtale/DataViewer.jsx
+++ b/static/dtale/DataViewer.jsx
@@ -238,7 +238,7 @@ class ReactDataViewer extends React.Component {
                       onScroll={this.props.closeColumnMenu}
                       cellRenderer={this._cellRenderer}
                       height={gridHeight}
-                      width={width - (this.props.menuPinned ? 185 : 3)}
+                      width={width - (this.props.menuPinned ? 188 : 3)}
                       columnWidth={({ index }) => gu.getColWidth(index, this.state)}
                       onSectionRendered={this._onSectionRendered}
                       ref={mg => (this._grid = mg)}

--- a/static/dtale/DataViewer.jsx
+++ b/static/dtale/DataViewer.jsx
@@ -219,53 +219,55 @@ class ReactDataViewer extends React.Component {
     return (
       <GridEventHandler propagateState={this.propagateState} gridState={this.state}>
         <DtaleHotkeys propagateState={this.propagateState} {...this.state} />
-        <InfiniteLoader
-          isRowLoaded={({ index }) => _.has(this.state, ["data", index])}
-          loadMoreRows={_.noop}
-          rowCount={this.state.rowCount}>
-          {({ onRowsRendered }) => {
-            this._onRowsRendered = onRowsRendered;
-            return (
-              <AutoSizer className="main-grid" onResize={() => this._grid.recomputeGridSize()}>
-                {({ width, height }) => {
-                  const gridHeight = height - (gu.hasNoInfo(this.state) ? 3 : 23);
-                  return [
-                    <DataViewerInfo key={0} width={width} {...this.state} propagateState={this.propagateState} />,
-                    <MultiGrid
-                      {...this.state}
-                      key={1}
-                      columnCount={gu.getActiveCols(this.state).length}
-                      onScroll={this.props.closeColumnMenu}
-                      cellRenderer={this._cellRenderer}
-                      height={gridHeight}
-                      width={width - 3}
-                      columnWidth={({ index }) => gu.getColWidth(index, this.state)}
-                      onSectionRendered={this._onSectionRendered}
-                      ref={mg => (this._grid = mg)}
-                    />,
-                  ];
-                }}
-              </AutoSizer>
-            );
-          }}
-        </InfiniteLoader>
-        <DataViewerMenu {...this.state} propagateState={this.propagateState} />
-        <Popup propagateState={this.propagateState} />
-        <Formatting
-          {..._.pick(this.state, ["data", "columns", "columnFormats", "nanDisplay"])}
-          selectedCol={_.get(this.state.selectedCols, "0")}
-          visible={formattingOpen}
-          propagateState={this.propagateState}
-        />
-        <MeasureText />
-        <ColumnMenu
-          {..._.pick(this.state, ["columns", "sortInfo", "columnFilters", "outlierFilters", "error"])}
-          backgroundMode={this.state.backgroundMode}
-          propagateState={this.propagateState}
-          noInfo={gu.hasNoInfo(this.state)}
-        />
-        <div id="edit-tt" className="hoverable__content edit-cell" style={{ display: "none" }}>
-          {Descriptions.editing}
+        <div style={{ display: "flex", width: "100%", height: "100%" }}>
+          <DataViewerMenu {...this.state} propagateState={this.propagateState} />
+          <InfiniteLoader
+            isRowLoaded={({ index }) => _.has(this.state, ["data", index])}
+            loadMoreRows={_.noop}
+            rowCount={this.state.rowCount}>
+            {({ onRowsRendered }) => {
+              this._onRowsRendered = onRowsRendered;
+              return (
+                <AutoSizer className="main-grid" onResize={() => this._grid.recomputeGridSize()}>
+                  {({ width, height }) => {
+                    const gridHeight = height - (gu.hasNoInfo(this.state) ? 3 : 23);
+                    return [
+                      <DataViewerInfo key={0} width={width} {...this.state} propagateState={this.propagateState} />,
+                      <MultiGrid
+                        {...this.state}
+                        key={1}
+                        columnCount={gu.getActiveCols(this.state).length}
+                        onScroll={this.props.closeColumnMenu}
+                        cellRenderer={this._cellRenderer}
+                        height={gridHeight}
+                        width={width - 3}
+                        columnWidth={({ index }) => gu.getColWidth(index, this.state)}
+                        onSectionRendered={this._onSectionRendered}
+                        ref={mg => (this._grid = mg)}
+                      />,
+                    ];
+                  }}
+                </AutoSizer>
+              );
+            }}
+          </InfiniteLoader>
+          <Popup propagateState={this.propagateState} />
+          <Formatting
+            {..._.pick(this.state, ["data", "columns", "columnFormats", "nanDisplay"])}
+            selectedCol={_.get(this.state.selectedCols, "0")}
+            visible={formattingOpen}
+            propagateState={this.propagateState}
+          />
+          <MeasureText />
+          <ColumnMenu
+            {..._.pick(this.state, ["columns", "sortInfo", "columnFilters", "outlierFilters", "error"])}
+            backgroundMode={this.state.backgroundMode}
+            propagateState={this.propagateState}
+            noInfo={gu.hasNoInfo(this.state)}
+          />
+          <div id="edit-tt" className="hoverable__content edit-cell" style={{ display: "none" }}>
+            {Descriptions.editing}
+          </div>
         </div>
       </GridEventHandler>
     );

--- a/static/dtale/GridEventHandler.jsx
+++ b/static/dtale/GridEventHandler.jsx
@@ -139,7 +139,7 @@ class ReactGridEventHandler extends React.Component {
 
   render() {
     return (
-      <div className="h-100 w-100" onMouseOver={this.handleMouseOver} onClick={this.handleClicks}>
+      <div className="h-100 w-100 d-flex" onMouseOver={this.handleMouseOver} onClick={this.handleClicks}>
         {this.props.children}
       </div>
     );

--- a/static/dtale/menu-descriptions.json
+++ b/static/dtale/menu-descriptions.json
@@ -24,5 +24,6 @@
   "pps": "PPS is an asymmetric, data-type-agnostic score that can detect linear or non-linear relationships between two columns. The score ranges from 0 (no predictive power) to 1 (perfect predictive power). It can be used as an alternative to the correlation (matrix). WARNING: This could take a while to load.",
   "network": "If you're currently viewing data containing information for a directed graph then try feeding it into our \"Network Viewer\"",
   "reload_data": "Force a reload of the data from the server for the current rows being viewing in the grid by clicking this button. This can be helpful when viewing the grid from within another application like jupyter or nested within another website.",
-  "merge": "Merge & Stack (concatenate vertically) dataframes currently loaded into D-Tale or upload additional ones for taht purpose."
+  "merge": "Merge & Stack (concatenate vertically) dataframes currently loaded into D-Tale or upload additional ones for that purpose.",
+  "pin_menu": "Toggle for pinning this menu to the left side of the screen."
 }

--- a/static/dtale/menu/DataViewerMenu.jsx
+++ b/static/dtale/menu/DataViewerMenu.jsx
@@ -15,6 +15,7 @@ import HeatMapOption from "./HeatMapOption";
 import InstancesOption from "./InstancesOption";
 import LowVarianceOption from "./LowVarianceOption";
 import { MenuItem } from "./MenuItem";
+import { MenuTooltip } from "./MenuTooltip";
 import MergeOption from "./MergeOption";
 import NetworkOption from "./NetworkOption";
 import RangeHighlightOption from "./RangeHighlightOption";
@@ -66,11 +67,13 @@ class ReactDataViewerMenu extends React.Component {
         {!menuPinned && menuOpen && (
           <GlobalHotKeys keyMap={{ CLOSE_MENU: "esc" }} handlers={{ CLOSE_MENU: closeMenu }} />
         )}
+        <MenuTooltip />
         <header className="title-font pb-1">D-TALE</header>
         <div
           style={{
             height: `calc(100vh - ${menuPinned ? 40 : 68}px)`,
             overflowY: "scroll",
+            overflowX: "hidden",
           }}>
           <ul>
             <XArrayOption columns={_.reject(this.props.columns, { name: "dtale_index" })} />

--- a/static/dtale/menu/DataViewerMenu.jsx
+++ b/static/dtale/menu/DataViewerMenu.jsx
@@ -14,6 +14,7 @@ import DuplicatesOption from "./DuplicatesOption";
 import HeatMapOption from "./HeatMapOption";
 import InstancesOption from "./InstancesOption";
 import LowVarianceOption from "./LowVarianceOption";
+import { MenuItem } from "./MenuItem";
 import MergeOption from "./MergeOption";
 import NetworkOption from "./NetworkOption";
 import RangeHighlightOption from "./RangeHighlightOption";
@@ -56,217 +57,209 @@ class ReactDataViewerMenu extends React.Component {
     const containerProps = menuPinned
       ? { className: "pinned-data-viewer-menu" }
       : {
-        className: "column-toggle__dropdown",
-        hidden: !menuOpen,
-        style: { minWidth: "13.65em", top: "1em", left: "0.5em" },
-      };
+          className: "column-toggle__dropdown",
+          hidden: !menuOpen,
+          style: { minWidth: "13.65em", top: "1em", left: "0.5em" },
+        };
     return (
       <div {...containerProps}>
-        {!menuPinned && menuOpen && <GlobalHotKeys keyMap={{ CLOSE_MENU: "esc" }} handlers={{ CLOSE_MENU: closeMenu }} />}
-        <header className="title-font">D-TALE</header>
-        <ul>
-          <XArrayOption columns={_.reject(this.props.columns, { name: "dtale_index" })} />
-          <DescribeOption open={buttonHandlers.DESCRIBE} />
-          <li className="hoverable">
-            <span className="toggler-action">
-              <button className="btn btn-plain" onClick={buttonHandlers.FILTER}>
-                <i className="fa fa-filter ml-2 mr-4" />
-                <span className="font-weight-bold">Custom Filter</span>
-              </button>
-            </span>
-            <div className="hoverable__content menu-description">{Descriptions.filter}</div>
-          </li>
-          <li className="hoverable">
-            <span className="toggler-action">
-              <button className="btn btn-plain" onClick={buttonHandlers.BUILD}>
-                <i className="ico-build" />
-                <span className="font-weight-bold">Build Column</span>
-              </button>
-            </span>
-            <div className="hoverable__content menu-description">{Descriptions.build}</div>
-          </li>
-          <MergeOption open={() => window.open(menuFuncs.fullPath("/dtale/popup/merge"), "_blank")} />
-          <li className="hoverable">
-            <span className="toggler-action">
-              <button className="btn btn-plain" onClick={openPopup("reshape", 400, 770)}>
-                <i className="fas fa-tools ml-2 mr-4" />
-                <span className="font-weight-bold">Summarize Data</span>
-              </button>
-            </span>
-            <div className="hoverable__content menu-description">{Descriptions.reshape}</div>
-          </li>
-          <DuplicatesOption open={buttonHandlers.DUPLICATES} />
-          <li className="hoverable">
-            <span className="toggler-action">
-              <button className="btn btn-plain" onClick={openTab("correlations")}>
-                <i className="ico-bubble-chart" />
-                <span className="font-weight-bold">Correlations</span>
-              </button>
-            </span>
-            <div className="hoverable__content menu-description">{Descriptions.corr}</div>
-          </li>
-          {(!pythonVersion || (pythonVersion[0] >= 3 && pythonVersion[1] >= 6)) && (
-            <li className="hoverable">
+        {!menuPinned && menuOpen && (
+          <GlobalHotKeys keyMap={{ CLOSE_MENU: "esc" }} handlers={{ CLOSE_MENU: closeMenu }} />
+        )}
+        <header className="title-font pb-1">D-TALE</header>
+        <div
+          style={{
+            height: `calc(100vh - ${menuPinned ? 40 : 68}px)`,
+            overflowY: "scroll",
+          }}>
+          <ul>
+            <XArrayOption columns={_.reject(this.props.columns, { name: "dtale_index" })} />
+            <DescribeOption open={buttonHandlers.DESCRIBE} />
+            <MenuItem description={Descriptions.filter}>
               <span className="toggler-action">
-                <button className="btn btn-plain" onClick={openTab("pps")}>
+                <button className="btn btn-plain" onClick={buttonHandlers.FILTER}>
+                  <i className="fa fa-filter ml-2 mr-4" />
+                  <span className="font-weight-bold">Custom Filter</span>
+                </button>
+              </span>
+            </MenuItem>
+            <MenuItem description={Descriptions.build}>
+              <span className="toggler-action">
+                <button className="btn btn-plain" onClick={buttonHandlers.BUILD}>
+                  <i className="ico-build" />
+                  <span className="font-weight-bold">Build Column</span>
+                </button>
+              </span>
+            </MenuItem>
+            <MergeOption open={() => window.open(menuFuncs.fullPath("/dtale/popup/merge"), "_blank")} />
+            <MenuItem description={Descriptions.reshape}>
+              <span className="toggler-action">
+                <button className="btn btn-plain" onClick={openPopup("reshape", 400, 770)}>
+                  <i className="fas fa-tools ml-2 mr-4" />
+                  <span className="font-weight-bold">Summarize Data</span>
+                </button>
+              </span>
+            </MenuItem>
+            <DuplicatesOption open={buttonHandlers.DUPLICATES} />
+            <MenuItem description={Descriptions.corr}>
+              <span className="toggler-action">
+                <button className="btn btn-plain" onClick={openTab("correlations")}>
                   <i className="ico-bubble-chart" />
-                  <span className="font-weight-bold">Predictive Power Score</span>
+                  <span className="font-weight-bold">Correlations</span>
                 </button>
               </span>
-              <div className="hoverable__content menu-description">{Descriptions.pps}</div>
-            </li>
-          )}
-          <li className="hoverable">
-            <span className="toggler-action">
-              <button className="btn btn-plain" onClick={buttonHandlers.CHARTS}>
-                <i className="ico-show-chart" />
-                <span className="font-weight-bold">Charts</span>
-              </button>
-            </span>
-            <div className="hoverable__content menu-description">{Descriptions.charts}</div>
-          </li>
-          <NetworkOption open={buttonHandlers.NETWORK} />
-          <HeatMapOption backgroundMode={backgroundMode} toggleBackground={toggleBackground} />
-          <li className="hoverable">
-            <span className="toggler-action">
-              <button className="btn btn-plain" onClick={toggleBackground("dtypes")}>
-                <div style={{ display: "inherit" }}>
-                  <div className={`bg-icon dtype-bg${backgroundMode === "dtypes" ? " spin" : ""}`} />
-                  <span className="font-weight-bold pl-4">Highlight Dtypes</span>
-                </div>
-              </button>
-            </span>
-            <div className="hoverable__content menu-description">{Descriptions.highlight_dtypes}</div>
-          </li>
-          <li className="hoverable">
-            <span className="toggler-action">
-              <button className="btn btn-plain" onClick={toggleBackground("missing")}>
-                <div style={{ display: "inherit" }}>
-                  <div className={`bg-icon missing-bg${backgroundMode === "missing" ? " spin" : ""}`} />
-                  <span className="font-weight-bold pl-4">Highlight Missing</span>
-                </div>
-              </button>
-            </span>
-            <div className="hoverable__content menu-description">{Descriptions.highlight_missings}</div>
-          </li>
-          <li className="hoverable">
-            <span className="toggler-action">
-              <button className="btn btn-plain" onClick={toggleOutlierBackground}>
-                <div style={{ display: "inherit" }}>
-                  <div className={`bg-icon outliers-bg${backgroundMode === "outliers" ? " spin" : ""}`} />
-                  <span className="font-weight-bold pl-4">Highlight Outliers</span>
-                </div>
-              </button>
-            </span>
-            <div className="hoverable__content menu-description">{Descriptions.highlight_outliers}</div>
-          </li>
-          <RangeHighlightOption {...this.props} />
-          <LowVarianceOption
-            toggleLowVarianceBackground={toggleBackground("lowVariance")}
-            backgroundMode={backgroundMode}
-          />
-          <InstancesOption open={openPopup("instances", 450, 750)} />
-          <li className="hoverable">
-            <span className="toggler-action">
-              <button className="btn btn-plain" onClick={buttonHandlers.CODE}>
-                <i className="ico-code" />
-                <span className="font-weight-bold">Code Export</span>
-              </button>
-            </span>
-            <div className="hoverable__content menu-description">{Descriptions.code}</div>
-          </li>
-          <li className="hoverable" style={{ color: "#565b68" }}>
-            <span className="toggler-action">
-              <i className="far fa-file" />
-            </span>
-            <span className="font-weight-bold pl-2">Export</span>
-            <div className="btn-group compact ml-auto mr-3 font-weight-bold column-sorting">
-              {_.map(
-                [
-                  ["CSV", "false"],
-                  ["TSV", "true"],
-                ],
-                ([label, tsv]) => (
-                  <button
-                    key={label}
-                    style={{ color: "#565b68" }}
-                    className="btn btn-primary font-weight-bold"
-                    onClick={exportFile(tsv)}>
-                    {label}
+            </MenuItem>
+            {(!pythonVersion || (pythonVersion[0] >= 3 && pythonVersion[1] >= 6)) && (
+              <MenuItem description={Descriptions.pps}>
+                <span className="toggler-action">
+                  <button className="btn btn-plain" onClick={openTab("pps")}>
+                    <i className="ico-bubble-chart" />
+                    <span className="font-weight-bold">Predictive Power Score</span>
                   </button>
-                )
-              )}
-            </div>
-            <div className="hoverable__content menu-description">{Descriptions.export}</div>
-          </li>
-          <UploadOption open={openPopup("upload", 450)} />
-          <li className="hoverable">
-            <span className="toggler-action">
-              <button className="btn btn-plain" onClick={refreshWidths}>
-                <i className="fas fa-columns ml-2 mr-4" />
-                <span className="font-weight-bold">Refresh Widths</span>
-              </button>
-            </span>
-            <div className="hoverable__content menu-description">{Descriptions.widths}</div>
-          </li>
-          <li className="hoverable">
-            <span className="toggler-action">
-              <button
-                className="btn btn-plain"
-                onClick={() =>
-                  this.props.openChart({
-                    type: "about",
-                    size: "sm",
-                    backdrop: true,
-                  })
-                }>
-                <i className="fa fa-info-circle la-lg mr-4 ml-1" />
-                <span className="font-weight-bold">About</span>
-              </button>
-            </span>
-            <div className="hoverable__content menu-description">{Descriptions.about}</div>
-          </li>
-          <ThemeOption />
-          <li className="hoverable">
-            <span className="toggler-action">
-              <button className="btn btn-plain" onClick={() => window.location.reload()}>
-                <i className="ico-sync" />
-                <span className="font-weight-bold">Reload Data</span>
-              </button>
-            </span>
-            <div className="hoverable__content menu-description">{Descriptions.reload_data}</div>
-          </li>
-          <li className="hoverable">
-            <span className="toggler-action">
-              <button className="btn btn-plain" onClick={this.props.toggleMenuPinned}>
-                <i className="fa fa-anchor la-lg mr-4 ml-1" />
-                <span className="font-weight-bold">{menuPinned ? "Unpin menu" : "Pin menu"}</span>
-              </button>
-            </span>
-            <div className="hoverable__content menu-description">{Descriptions.pin_menu}</div>
-          </li>
-          <ConditionalRender display={iframe}>
-            <li>
+                </span>
+              </MenuItem>
+            )}
+            <MenuItem description={Descriptions.charts}>
               <span className="toggler-action">
-                <button className="btn btn-plain" onClick={() => window.open(window.location.pathname, "_blank")}>
-                  <i className="ico-open-in-new" />
-                  <span className="font-weight-bold">Open In New Tab</span>
+                <button className="btn btn-plain" onClick={buttonHandlers.CHARTS}>
+                  <i className="ico-show-chart" />
+                  <span className="font-weight-bold">Charts</span>
                 </button>
               </span>
-            </li>
-          </ConditionalRender>
-          <ConditionalRender display={hideShutdown == false}>
-            <li className="hoverable">
+            </MenuItem>
+            <NetworkOption open={buttonHandlers.NETWORK} />
+            <HeatMapOption backgroundMode={backgroundMode} toggleBackground={toggleBackground} />
+            <MenuItem description={Descriptions.highlight_dtypes}>
               <span className="toggler-action">
-                <a className="btn btn-plain" href="/shutdown">
-                  <i className="fa fa-power-off ml-2 mr-4" />
-                  <span className="font-weight-bold">Shutdown</span>
-                </a>
+                <button className="btn btn-plain" onClick={toggleBackground("dtypes")}>
+                  <div style={{ display: "inherit" }}>
+                    <div className={`bg-icon dtype-bg${backgroundMode === "dtypes" ? " spin" : ""}`} />
+                    <span className="font-weight-bold pl-4">Highlight Dtypes</span>
+                  </div>
+                </button>
               </span>
-              <div className="hoverable__content menu-description">{Descriptions.shutdown}</div>
-            </li>
-          </ConditionalRender>
-        </ul>
+            </MenuItem>
+            <MenuItem description={Descriptions.highlight_missings}>
+              <span className="toggler-action">
+                <button className="btn btn-plain" onClick={toggleBackground("missing")}>
+                  <div style={{ display: "inherit" }}>
+                    <div className={`bg-icon missing-bg${backgroundMode === "missing" ? " spin" : ""}`} />
+                    <span className="font-weight-bold pl-4">Highlight Missing</span>
+                  </div>
+                </button>
+              </span>
+            </MenuItem>
+            <MenuItem description={Descriptions.highlight_outliers}>
+              <span className="toggler-action">
+                <button className="btn btn-plain" onClick={toggleOutlierBackground}>
+                  <div style={{ display: "inherit" }}>
+                    <div className={`bg-icon outliers-bg${backgroundMode === "outliers" ? " spin" : ""}`} />
+                    <span className="font-weight-bold pl-4">Highlight Outliers</span>
+                  </div>
+                </button>
+              </span>
+            </MenuItem>
+            <RangeHighlightOption {...this.props} />
+            <LowVarianceOption
+              toggleLowVarianceBackground={toggleBackground("lowVariance")}
+              backgroundMode={backgroundMode}
+            />
+            <InstancesOption open={openPopup("instances", 450, 750)} />
+            <MenuItem description={Descriptions.code}>
+              <span className="toggler-action">
+                <button className="btn btn-plain" onClick={buttonHandlers.CODE}>
+                  <i className="ico-code" />
+                  <span className="font-weight-bold">Code Export</span>
+                </button>
+              </span>
+            </MenuItem>
+            <MenuItem style={{ color: "#565b68" }} description={Descriptions.export}>
+              <span className="toggler-action">
+                <i className="far fa-file" />
+              </span>
+              <span className="font-weight-bold pl-2">Export</span>
+              <div className="btn-group compact ml-auto mr-3 font-weight-bold column-sorting">
+                {_.map(
+                  [
+                    ["CSV", "false"],
+                    ["TSV", "true"],
+                  ],
+                  ([label, tsv]) => (
+                    <button
+                      key={label}
+                      style={{ color: "#565b68" }}
+                      className="btn btn-primary font-weight-bold"
+                      onClick={exportFile(tsv)}>
+                      {label}
+                    </button>
+                  )
+                )}
+              </div>
+            </MenuItem>
+            <UploadOption open={openPopup("upload", 450)} />
+            <MenuItem description={Descriptions.widths}>
+              <span className="toggler-action">
+                <button className="btn btn-plain" onClick={refreshWidths}>
+                  <i className="fas fa-columns ml-2 mr-4" />
+                  <span className="font-weight-bold">Refresh Widths</span>
+                </button>
+              </span>
+            </MenuItem>
+            <MenuItem description={Descriptions.about}>
+              <span className="toggler-action">
+                <button
+                  className="btn btn-plain"
+                  onClick={() =>
+                    this.props.openChart({
+                      type: "about",
+                      size: "sm",
+                      backdrop: true,
+                    })
+                  }>
+                  <i className="fa fa-info-circle la-lg mr-4 ml-1" />
+                  <span className="font-weight-bold">About</span>
+                </button>
+              </span>
+            </MenuItem>
+            <ThemeOption />
+            <MenuItem description={Descriptions.reload_data}>
+              <span className="toggler-action">
+                <button className="btn btn-plain" onClick={() => window.location.reload()}>
+                  <i className="ico-sync" />
+                  <span className="font-weight-bold">Reload Data</span>
+                </button>
+              </span>
+            </MenuItem>
+            <MenuItem description={Descriptions.pin_menu}>
+              <span className="toggler-action">
+                <button className="btn btn-plain" onClick={this.props.toggleMenuPinned}>
+                  <i className="fa fa-anchor la-lg mr-3 ml-1" />
+                  <span className="font-weight-bold">{menuPinned ? "Unpin menu" : "Pin menu"}</span>
+                </button>
+              </span>
+            </MenuItem>
+            <ConditionalRender display={iframe}>
+              <li>
+                <span className="toggler-action">
+                  <button className="btn btn-plain" onClick={() => window.open(window.location.pathname, "_blank")}>
+                    <i className="ico-open-in-new" />
+                    <span className="font-weight-bold">Open In New Tab</span>
+                  </button>
+                </span>
+              </li>
+            </ConditionalRender>
+            <ConditionalRender display={hideShutdown == false}>
+              <MenuItem description={Descriptions.shutdown}>
+                <span className="toggler-action">
+                  <a className="btn btn-plain" href="/shutdown">
+                    <i className="fa fa-power-off ml-2 mr-4" />
+                    <span className="font-weight-bold">Shutdown</span>
+                  </a>
+                </span>
+              </MenuItem>
+            </ConditionalRender>
+          </ul>
+        </div>
       </div>
     );
   }
@@ -291,7 +284,7 @@ const ReduxDataViewerMenu = connect(
   dispatch => ({
     openChart: chartProps => dispatch(openChart(chartProps)),
     toggleMenuPinned: () => dispatch({ type: "toggle-menu-pinned" }),
-   })
+  })
 )(ReactDataViewerMenu);
 
 export { ReduxDataViewerMenu as DataViewerMenu, ReactDataViewerMenu };

--- a/static/dtale/menu/DataViewerMenu.jsx
+++ b/static/dtale/menu/DataViewerMenu.jsx
@@ -24,7 +24,7 @@ import menuFuncs from "./dataViewerMenuUtils";
 
 class ReactDataViewerMenu extends React.Component {
   render() {
-    const { hideShutdown, dataId, menuOpen, backgroundMode, pythonVersion } = this.props;
+    const { hideShutdown, dataId, menuOpen, menuPinned, backgroundMode, pythonVersion } = this.props;
     const iframe = global.top !== global.self;
     const buttonHandlers = menuFuncs.buildHotkeyHandlers(this.props);
     const { openTab, openPopup } = buttonHandlers;
@@ -53,12 +53,16 @@ class ReactDataViewerMenu extends React.Component {
       $(document).unbind("click.gridActions");
       this.props.propagateState({ menuOpen: false });
     };
+    const containerProps = menuPinned
+      ? { className: "pinned-data-viewer-menu" }
+      : {
+        className: "column-toggle__dropdown",
+        hidden: !menuOpen,
+        style: { minWidth: "13.65em", top: "1em", left: "0.5em" },
+      };
     return (
-      <div
-        className="column-toggle__dropdown"
-        hidden={!menuOpen}
-        style={{ minWidth: "13.65em", top: "1em", left: "0.5em" }}>
-        {menuOpen && <GlobalHotKeys keyMap={{ CLOSE_MENU: "esc" }} handlers={{ CLOSE_MENU: closeMenu }} />}
+      <div {...containerProps}>
+        {!menuPinned && menuOpen && <GlobalHotKeys keyMap={{ CLOSE_MENU: "esc" }} handlers={{ CLOSE_MENU: closeMenu }} />}
         <header className="title-font">D-TALE</header>
         <ul>
           <XArrayOption columns={_.reject(this.props.columns, { name: "dtale_index" })} />
@@ -232,6 +236,15 @@ class ReactDataViewerMenu extends React.Component {
             </span>
             <div className="hoverable__content menu-description">{Descriptions.reload_data}</div>
           </li>
+          <li className="hoverable">
+            <span className="toggler-action">
+              <button className="btn btn-plain" onClick={this.props.toggleMenuPinned}>
+                <i className="fa fa-anchor la-lg mr-4 ml-1" />
+                <span className="font-weight-bold">{menuPinned ? "Unpin menu" : "Pin menu"}</span>
+              </button>
+            </span>
+            <div className="hoverable__content menu-description">{Descriptions.pin_menu}</div>
+          </li>
           <ConditionalRender display={iframe}>
             <li>
               <span className="toggler-action">
@@ -269,11 +282,16 @@ ReactDataViewerMenu.propTypes = {
   hideShutdown: PropTypes.bool,
   dataId: PropTypes.string.isRequired,
   pythonVersion: PropTypes.arrayOf(PropTypes.number),
+  menuPinned: PropTypes.bool,
+  toggleMenuPinned: PropTypes.func,
 };
 
 const ReduxDataViewerMenu = connect(
-  state => _.pick(state, ["dataId", "hideShutdown", "pythonVersion"]),
-  dispatch => ({ openChart: chartProps => dispatch(openChart(chartProps)) })
+  state => _.pick(state, ["dataId", "hideShutdown", "pythonVersion", "menuPinned"]),
+  dispatch => ({
+    openChart: chartProps => dispatch(openChart(chartProps)),
+    toggleMenuPinned: () => dispatch({ type: "toggle-menu-pinned" }),
+   })
 )(ReactDataViewerMenu);
 
 export { ReduxDataViewerMenu as DataViewerMenu, ReactDataViewerMenu };

--- a/static/dtale/menu/DataViewerMenuHolder.jsx
+++ b/static/dtale/menu/DataViewerMenuHolder.jsx
@@ -22,7 +22,7 @@ class ReactDataViewerMenuHolder extends React.Component {
     return (
       <div style={style} className="menu-toggle">
         <div className="crossed">
-          {menuPinned ? null : (
+          {!menuPinned && (
             <div
               className={`grid-menu ${menuOpen ? "open" : ""}`}
               style={{
@@ -52,7 +52,8 @@ ReactDataViewerMenuHolder.propTypes = {
   propagateState: PropTypes.func,
 };
 
-const ReduxDataViewerMenuHolder = connect(({ theme, menuPinned }) => ({ theme, menuPinned }))(
-  ReactDataViewerMenuHolder
-);
+const ReduxDataViewerMenuHolder = connect(({ theme, menuPinned }) => ({
+  theme,
+  menuPinned,
+}))(ReactDataViewerMenuHolder);
 export { ReduxDataViewerMenuHolder as DataViewerMenuHolder, ReactDataViewerMenuHolder };

--- a/static/dtale/menu/DataViewerMenuHolder.jsx
+++ b/static/dtale/menu/DataViewerMenuHolder.jsx
@@ -11,7 +11,7 @@ class ReactDataViewerMenuHolder extends React.Component {
   }
 
   render() {
-    const { style, propagateState, menuOpen, rowCount, theme, columns, backgroundMode } = this.props;
+    const { style, propagateState, menuOpen, menuPinned, rowCount, theme, columns, backgroundMode } = this.props;
     const activeCols = gu.getActiveCols({ columns, backgroundMode });
     const menuHandler = menuUtils.openMenu(
       "gridActions",
@@ -22,15 +22,17 @@ class ReactDataViewerMenuHolder extends React.Component {
     return (
       <div style={style} className="menu-toggle">
         <div className="crossed">
-          <div
-            className={`grid-menu ${menuOpen ? "open" : ""}`}
-            style={{
-              background: gu.isLight(theme) ? "white" : "black",
-              color: gu.isLight(theme) ? "black" : "white",
-            }}
-            onClick={menuHandler}>
-            <span>&#8227;</span>
-          </div>
+          {menuPinned ? null : (
+            <div
+              className={`grid-menu ${menuOpen ? "open" : ""}`}
+              style={{
+                background: gu.isLight(theme) ? "white" : "black",
+                color: gu.isLight(theme) ? "black" : "white",
+              }}
+              onClick={menuHandler}>
+              <span>&#8227;</span>
+            </div>
+          )}
           <div className="rows">{rowCount ? rowCount - 1 : 0}</div>
           <div className="cols">{activeCols.length ? activeCols.length - 1 : 0}</div>
         </div>
@@ -45,9 +47,12 @@ ReactDataViewerMenuHolder.propTypes = {
   columns: PropTypes.arrayOf(PropTypes.object),
   backgroundMode: PropTypes.string,
   menuOpen: PropTypes.bool,
+  menuPinned: PropTypes.bool,
   rowCount: PropTypes.number,
   propagateState: PropTypes.func,
 };
 
-const ReduxDataViewerMenuHolder = connect(({ theme }) => ({ theme }))(ReactDataViewerMenuHolder);
+const ReduxDataViewerMenuHolder = connect(({ theme, menuPinned }) => ({ theme, menuPinned }))(
+  ReactDataViewerMenuHolder
+);
 export { ReduxDataViewerMenuHolder as DataViewerMenuHolder, ReactDataViewerMenuHolder };

--- a/static/dtale/menu/DescribeOption.jsx
+++ b/static/dtale/menu/DescribeOption.jsx
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import Descriptions from "../menu-descriptions.json";
+import { MenuItem } from "./MenuItem";
 
 class DescribeOption extends React.Component {
   constructor(props) {
@@ -10,15 +11,14 @@ class DescribeOption extends React.Component {
 
   render() {
     return (
-      <li className="hoverable">
+      <MenuItem description={Descriptions.describe}>
         <span className="toggler-action">
           <button className="btn btn-plain" onClick={this.props.open}>
             <i className="ico-view-column" />
             <span className="font-weight-bold">Describe</span>
           </button>
         </span>
-        <div className="hoverable__content menu-description">{Descriptions.describe}</div>
-      </li>
+      </MenuItem>
     );
   }
 }

--- a/static/dtale/menu/DuplicatesOption.jsx
+++ b/static/dtale/menu/DuplicatesOption.jsx
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import Descriptions from "../menu-descriptions.json";
+import { MenuItem } from "./MenuItem";
 
 class DuplicatesOption extends React.Component {
   constructor(props) {
@@ -10,15 +11,14 @@ class DuplicatesOption extends React.Component {
 
   render() {
     return (
-      <li className="hoverable">
+      <MenuItem description={Descriptions.duplicates}>
         <span className="toggler-action">
           <button className="btn btn-plain" onClick={this.props.open}>
             <i className="fas fa-clone ml-2 mr-4" />
             <span className="font-weight-bold">Duplicates</span>
           </button>
         </span>
-        <div className="hoverable__content menu-description">{Descriptions.duplicates}</div>
-      </li>
+      </MenuItem>
     );
   }
 }

--- a/static/dtale/menu/HeatMapOption.jsx
+++ b/static/dtale/menu/HeatMapOption.jsx
@@ -4,6 +4,7 @@ import React from "react";
 
 import { exports as gu } from "../gridUtils";
 import Descriptions from "../menu-descriptions.json";
+import { MenuItem } from "./MenuItem";
 
 class HeatMapOption extends React.Component {
   constructor(props) {
@@ -13,7 +14,7 @@ class HeatMapOption extends React.Component {
   render() {
     const { backgroundMode, toggleBackground } = this.props;
     return (
-      <li className="hoverable" style={{ color: "#565b68" }}>
+      <MenuItem style={{ color: "#565b68" }} description={Descriptions.heatmap}>
         <span className="toggler-action">
           <i className={`fa fa-${gu.heatmapActive(backgroundMode) ? "fire-extinguisher" : "fire-alt"} ml-2 mr-4`} />
         </span>
@@ -38,8 +39,7 @@ class HeatMapOption extends React.Component {
             )
           )}
         </div>
-        <div className="hoverable__content menu-description">{Descriptions.heatmap}</div>
-      </li>
+      </MenuItem>
     );
   }
 }

--- a/static/dtale/menu/InstancesOption.jsx
+++ b/static/dtale/menu/InstancesOption.jsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import app from "../../reducers/dtale";
 import Descriptions from "../menu-descriptions.json";
+import { MenuItem } from "./MenuItem";
 
 class InstancesOption extends React.Component {
   constructor(props) {
@@ -12,7 +13,7 @@ class InstancesOption extends React.Component {
   render() {
     const processCt = app.getHiddenValue("processes");
     return (
-      <li className="hoverable">
+      <MenuItem description={Descriptions.instances}>
         <span className="toggler-action">
           <button className="btn btn-plain" onClick={this.props.open}>
             <i className="ico-apps" />
@@ -22,10 +23,7 @@ class InstancesOption extends React.Component {
             </span>
           </button>
         </span>
-        <div className="hoverable__content menu-description">
-          <span>{Descriptions.instances}</span>
-        </div>
-      </li>
+      </MenuItem>
     );
   }
 }

--- a/static/dtale/menu/LowVarianceOption.jsx
+++ b/static/dtale/menu/LowVarianceOption.jsx
@@ -1,6 +1,8 @@
 import PropTypes from "prop-types";
 import React from "react";
 
+import { MenuItem } from "./MenuItem";
+
 require("./LowVarianceOption.css");
 
 class LowVarianceOption extends React.Component {
@@ -12,22 +14,25 @@ class LowVarianceOption extends React.Component {
     const { toggleLowVarianceBackground, backgroundMode } = this.props;
     const iconClass = `ico-check-box${backgroundMode == "lowVariance" ? "" : "-outline-blank"}`;
     return (
-      <li className="hoverable low-variance">
+      <MenuItem
+        className="hoverable low-variance"
+        description={
+          <>
+            <span>Show flags on column headers where both these conditions are true:</span>
+            <ul className="low-variance-conditions">
+              <li>{"Count of unique values / column size < 10%"}</li>
+              <li>{"Count of most common value / Count of second most common value > 20"}</li>
+            </ul>
+            <span>{`You can view variance information by clicking the "Variance" option in the column menu.`}</span>
+          </>
+        }>
         <span className="toggler-action">
           <button className="btn btn-plain" onClick={toggleLowVarianceBackground}>
             <i className={iconClass} style={{ marginTop: "-.25em" }} />
             <span className="font-weight-bold">Low Variance Flag</span>
           </button>
         </span>
-        <div className="hoverable__content menu-description">
-          <span>Show flags on column headers where both these conditions are true:</span>
-          <ul className="low-variance-conditions">
-            <li>{"Count of unique values / column size < 10%"}</li>
-            <li>{"Count of most common value / Count of second most common value > 20"}</li>
-          </ul>
-          <span>{`You can view variance information by clicking the "Variance" option in the column menu.`}</span>
-        </div>
-      </li>
+      </MenuItem>
     );
   }
 }

--- a/static/dtale/menu/MenuItem.jsx
+++ b/static/dtale/menu/MenuItem.jsx
@@ -1,0 +1,47 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { connect } from "react-redux";
+
+class ReactMenuItem extends React.Component {
+  constructor(props) {
+    super(props);
+    this.ref = React.createRef();
+  }
+
+  render() {
+    return (
+      <li
+        className={this.props.className}
+        style={this.props.style}
+        ref={this.ref}
+        onMouseOver={() => {
+          this.props.showTooltip(this.ref.current, this.props.description);
+        }}
+        onMouseLeave={this.props.hideTooltip}>
+        {this.props.children}
+      </li>
+    );
+  }
+}
+ReactMenuItem.displayName = "MenuItem";
+ReactMenuItem.propTypes = {
+  children: PropTypes.node,
+  description: PropTypes.node,
+  className: PropTypes.string,
+  style: PropTypes.object,
+  showTooltip: PropTypes.func,
+  hideTooltip: PropTypes.func,
+};
+ReactMenuItem.defaultProps = {
+  className: "hoverable",
+};
+
+const ReduxMenuItem = connect(
+  () => ({}),
+  dispatch => ({
+    showTooltip: (element, content) => dispatch({ type: "show-menu-tooltip", element, content }),
+    hideTooltip: () => dispatch({ type: "hide-menu-tooltip" }),
+  })
+)(ReactMenuItem);
+
+export { ReduxMenuItem as MenuItem, ReactMenuItem };

--- a/static/dtale/menu/MenuTooltip.jsx
+++ b/static/dtale/menu/MenuTooltip.jsx
@@ -1,0 +1,49 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { connect } from "react-redux";
+
+class ReactMenuTooltip extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      style: { display: "none" },
+    };
+    this.computeStyle = this.computeStyle.bind(this);
+  }
+
+  computeStyle() {
+    if (this.props.visible) {
+      const rect = this.props.element.getBoundingClientRect();
+      return {
+        display: "block",
+        top: `calc(${rect.top}px - 0.8em)`,
+        left: `calc(${rect.left + rect.width}px - 0.5em)`,
+      };
+    }
+    return { display: "none" };
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.visible !== prevProps.visible) {
+      this.setState({ style: this.computeStyle() });
+    }
+  }
+
+  render() {
+    return (
+      <div className="hoverable__content menu-description" style={this.state.style}>
+        {this.props.content}
+      </div>
+    );
+  }
+}
+ReactMenuTooltip.displayName = "MenuTooltip";
+ReactMenuTooltip.propTypes = {
+  visible: PropTypes.bool,
+  element: PropTypes.instanceOf(Element),
+  content: PropTypes.node,
+};
+
+const ReduxMenuTooltip = connect(state => state.menuTooltip)(ReactMenuTooltip);
+
+export { ReduxMenuTooltip as MenuTooltip, ReactMenuTooltip };

--- a/static/dtale/menu/MergeOption.jsx
+++ b/static/dtale/menu/MergeOption.jsx
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import Descriptions from "../menu-descriptions.json";
+import { MenuItem } from "./MenuItem";
 
 class UploadOption extends React.Component {
   constructor(props) {
@@ -10,15 +11,14 @@ class UploadOption extends React.Component {
 
   render() {
     return (
-      <li className="hoverable">
+      <MenuItem description={Descriptions.merge}>
         <span className="toggler-action">
           <button className="btn btn-plain" onClick={this.props.open}>
             <i className="fas fa-object-group pl-3 pr-3" />
             <span className="font-weight-bold">Merge & Stack</span>
           </button>
         </span>
-        <div className="hoverable__content menu-description">{Descriptions.merge}</div>
-      </li>
+      </MenuItem>
     );
   }
 }

--- a/static/dtale/menu/NetworkOption.jsx
+++ b/static/dtale/menu/NetworkOption.jsx
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import Descriptions from "../menu-descriptions.json";
+import { MenuItem } from "./MenuItem";
 
 class NetworkOption extends React.Component {
   constructor(props) {
@@ -10,15 +11,14 @@ class NetworkOption extends React.Component {
 
   render() {
     return (
-      <li className="hoverable">
+      <MenuItem description={Descriptions.network}>
         <span className="toggler-action">
           <button className="btn btn-plain" onClick={this.props.open}>
             <i className="fas fa-project-diagram ml-2 mr-4" />
             <span className="font-weight-bold">Network Viewer</span>
           </button>
         </span>
-        <div className="hoverable__content menu-description">{Descriptions.network}</div>
-      </li>
+      </MenuItem>
     );
   }
 }

--- a/static/dtale/menu/RangeHighlightOption.jsx
+++ b/static/dtale/menu/RangeHighlightOption.jsx
@@ -4,6 +4,7 @@ import React from "react";
 
 import { Bouncer } from "../../Bouncer";
 import Descriptions from "../menu-descriptions.json";
+import { MenuItem } from "./MenuItem";
 
 class RangeHighlightOption extends React.Component {
   constructor(props) {
@@ -20,7 +21,7 @@ class RangeHighlightOption extends React.Component {
       this.props.propagateState({ rangeHighlight, backgroundMode: null });
     };
     return (
-      <li className="hoverable">
+      <MenuItem description={Descriptions.highlight_range}>
         <span className="toggler-action">
           <button className="btn btn-plain" onClick={openRangeHightlight}>
             <div style={{ display: "inherit" }}>
@@ -39,8 +40,7 @@ class RangeHighlightOption extends React.Component {
             <i className="ico-close-circle pointer mr-3 btn-plain" onClick={turnOffRangeHighlight} />
           </div>
         )}
-        <div className="hoverable__content menu-description">{Descriptions.highlight_range}</div>
-      </li>
+      </MenuItem>
     );
   }
 }

--- a/static/dtale/menu/ThemeOption.jsx
+++ b/static/dtale/menu/ThemeOption.jsx
@@ -7,6 +7,7 @@ import actions from "../../actions/dtale";
 import { exports as gu } from "../gridUtils";
 import Descriptions from "../menu-descriptions.json";
 import serverStateManagement from "../serverStateManagement";
+import { MenuItem } from "./MenuItem";
 
 class ReactThemeOption extends React.Component {
   constructor(props) {
@@ -17,7 +18,7 @@ class ReactThemeOption extends React.Component {
     const { setTheme, theme } = this.props;
     const updateTheme = newTheme => () => serverStateManagement.updateTheme(newTheme, () => setTheme(newTheme));
     return (
-      <li className="hoverable" style={{ color: "#565b68" }}>
+      <MenuItem style={{ color: "#565b68" }} description={Descriptions.theme}>
         <span className="toggler-action">
           <i className="fas fa-adjust" />
         </span>
@@ -33,8 +34,7 @@ class ReactThemeOption extends React.Component {
             </button>
           ))}
         </div>
-        <div className="hoverable__content menu-description">{Descriptions.theme}</div>
-      </li>
+      </MenuItem>
     );
   }
 }

--- a/static/dtale/menu/UploadOption.jsx
+++ b/static/dtale/menu/UploadOption.jsx
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import Descriptions from "../menu-descriptions.json";
+import { MenuItem } from "./MenuItem";
 
 class UploadOption extends React.Component {
   constructor(props) {
@@ -10,15 +11,14 @@ class UploadOption extends React.Component {
 
   render() {
     return (
-      <li className="hoverable">
+      <MenuItem description={Descriptions.upload}>
         <span className="toggler-action">
           <button className="btn btn-plain" onClick={this.props.open}>
             <i className="ico-file-upload" />
             <span className="font-weight-bold">Load Data</span>
           </button>
         </span>
-        <div className="hoverable__content menu-description">{Descriptions.upload}</div>
-      </li>
+      </MenuItem>
     );
   }
 }

--- a/static/dtale/menu/XArrayOption.jsx
+++ b/static/dtale/menu/XArrayOption.jsx
@@ -5,6 +5,7 @@ import { connect } from "react-redux";
 
 import { openChart } from "../../actions/charts";
 import Descriptions from "../menu-descriptions.json";
+import { MenuItem } from "./MenuItem";
 
 const DESCRIPTION = "View individual xarray dimensions. You are currently viewing:";
 
@@ -21,35 +22,32 @@ function renderDimensionSelection(dimensionSelection) {
 class ReactXArrayOption extends React.Component {
   constructor(props) {
     super(props);
+    this.buttonRef = React.createRef();
   }
 
   render() {
     const openXArrayPopup = type => this.props.openChart(_.assignIn({ type }, this.props));
     if (this.props.xarray) {
       return (
-        <li className="hoverable">
+        <MenuItem description={`${DESCRIPTION} ${renderDimensionSelection(this.props.xarrayDim)}`}>
           <span className="toggler-action">
             <button className="btn btn-plain" onClick={() => openXArrayPopup("xarray-dimensions")}>
               <i className="ico-key" />
               <span className="font-weight-bold">XArray Dimensions</span>
             </button>
           </span>
-          <div className="hoverable__content menu-description">
-            {`${DESCRIPTION} ${renderDimensionSelection(this.props.xarrayDim)}`}
-          </div>
-        </li>
+        </MenuItem>
       );
     }
     return (
-      <li className="hoverable">
+      <MenuItem description={Descriptions.xarray_conversion}>
         <span className="toggler-action">
-          <button className="btn btn-plain" onClick={() => openXArrayPopup("xarray-indexes")}>
+          <button className="btn btn-plain" ref={this.buttonRef} onClick={() => openXArrayPopup("xarray-indexes")}>
             <i className="ico-tune" />
             <span className="font-weight-bold">Convert To XArray</span>
           </button>
         </span>
-        <div className="hoverable__content menu-description">{Descriptions.xarray_conversion}</div>
-      </li>
+      </MenuItem>
     );
   }
 }

--- a/static/dtale/menu/XArrayOption.jsx
+++ b/static/dtale/menu/XArrayOption.jsx
@@ -22,7 +22,6 @@ function renderDimensionSelection(dimensionSelection) {
 class ReactXArrayOption extends React.Component {
   constructor(props) {
     super(props);
-    this.buttonRef = React.createRef();
   }
 
   render() {
@@ -42,7 +41,7 @@ class ReactXArrayOption extends React.Component {
     return (
       <MenuItem description={Descriptions.xarray_conversion}>
         <span className="toggler-action">
-          <button className="btn btn-plain" ref={this.buttonRef} onClick={() => openXArrayPopup("xarray-indexes")}>
+          <button className="btn btn-plain" onClick={() => openXArrayPopup("xarray-indexes")}>
             <i className="ico-tune" />
             <span className="font-weight-bold">Convert To XArray</span>
           </button>

--- a/static/reducers/dtale.js
+++ b/static/reducers/dtale.js
@@ -198,6 +198,17 @@ function menuPinned(state = false, action = {}) {
   }
 }
 
+function menuTooltip(state = { visible: false }, action = {}) {
+  switch (action.type) {
+    case "show-menu-tooltip":
+      return { visible: true, element: action.element, content: action.content };
+    case "hide-menu-tooltip":
+      return { visible: false };
+    default:
+      return state;
+  }
+}
+
 const dtaleStore = combineReducers({
   chartData,
   hideShutdown,
@@ -216,6 +227,7 @@ const dtaleStore = combineReducers({
   pythonVersion,
   isPreview,
   menuPinned,
+  menuTooltip,
 });
 
 export default { store: dtaleStore, getHiddenValue, toJson };

--- a/static/reducers/dtale.js
+++ b/static/reducers/dtale.js
@@ -189,6 +189,15 @@ function isPreview(state = false, action = {}) {
   }
 }
 
+function menuPinned(state = false, action = {}) {
+  switch (action.type) {
+    case "toggle-menu-pinned":
+      return !state;
+    default:
+      return state;
+  }
+}
+
 const dtaleStore = combineReducers({
   chartData,
   hideShutdown,
@@ -206,6 +215,7 @@ const dtaleStore = combineReducers({
   settings,
   pythonVersion,
   isPreview,
+  menuPinned,
 });
 
 export default { store: dtaleStore, getHiddenValue, toJson };

--- a/test_env.js
+++ b/test_env.js
@@ -14,11 +14,6 @@ jest.mock("react-syntax-highlighter/dist/esm/styles/hljs", () => ({ docco: {} })
 // globally mock this until we actually start to test it
 jest.mock("plotly.js-dist", () => ({ newPlot: () => undefined }));
 
-// this is required because cacheable-lookup creates an open handle due to it's use of AsyncResolver
-jest.mock("cacheable-lookup", () => ({
-  default: () => ({ lookup: () => ({}) }),
-}));
-
 jest.mock("chartjs-plugin-zoom", () => ({}));
 jest.mock("chartjs-chart-box-and-violin-plot/build/Chart.BoxPlot.js", () => ({}));
 jest.mock("chartjs-plugin-trendline", () => ({}));


### PR DESCRIPTION
Certain workflows require frequent menu access (ex: if you are fiddling around with custom filters and need to go through a lot of trial & error to get them just right), so this is just a small QoL update to reduce clicks.  It's also a nice option for new users, since it makes it easy to see all the available functionality while they're testing it out

(I'm sure I'll need to make some tweaks, I'm just getting the ball rolling)

I also haven't been able to test out the build, my circleci setup seems to be busted and I can't get any new branches to show up..hm