### PR TITLE
Updating developer start server commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1459,7 +1459,7 @@ $ git clone ssh://git@github.com:manahl/dtale.git
 # install the dependencies
 $ python setup.py develop
 # start the server
-$ python dtale --csv-path /home/jdoe/my_csv.csv --csv-parse_dates date
+$ dtale --csv-path /home/jdoe/my_csv.csv --csv-parse_dates date
 ```
 
 You can also run dtale from PyDev directly.


### PR DESCRIPTION
Update developer start server commands.  Currently the "start the server" command in the readme will yield an error:
`can't find '__main__' module in 'dtale'`