### PR TITLE
Added option for JSONL line files

### DIFF
--- a/dtale/cli/loaders/json_loader.py
+++ b/dtale/cli/loaders/json_loader.py
@@ -16,6 +16,7 @@ LOADER_PROPS = [
         name="convert_dates",
         help="comma-separated string of column names which should be parsed as dates",
     ),
+    dict(name="lines", help="Use if the file is a JSONL line file"),
 ]
 
 


### PR DESCRIPTION
This PR adds the option `--json-lines 1` for `--json-path` to properly load JSONL line files. Any value except `""` will evaluate to True.

JSONL is a file format that leaves off the initial `[` and the last `]` and each line is a JSON representation. 

For more information, see:

1. https://pandas.pydata.org/docs/reference/api/pandas.read_json.html (lines new in 1.3.0)
2. https://jsonlines.org/