### PR TITLE
Fix filtering string columns with special characters and explicitly support regex

### DIFF
--- a/dtale/column_filters.py
+++ b/dtale/column_filters.py
@@ -125,13 +125,14 @@ class StringFilter(MissingFilter):
                 raw if case_sensitive else raw.lower(),
             )
             fltr["query"] = handle_ne(fltr["query"], operand)
-        elif action == "contains":
+        elif action in ["contains", "regex"]:
             fltr["query"] = (
-                "{}.str.contains({!r}, na=False, case={}, regex=False)".format(
+                "{}.str.contains({!r}, na=False, case={}, regex={})".format(
                     build_col_key(self.column),
                     raw,
                     "True" if case_sensitive else "False",
-            ))
+                    "True" if action == "regex" else "False",
+                ))
             fltr["query"] = handle_ne(fltr["query"], operand)
         elif action == "length":
             if "," in raw:

--- a/frontend/static/dtale/DataViewerState.ts
+++ b/frontend/static/dtale/DataViewerState.ts
@@ -56,7 +56,7 @@ export interface Bounds {
 }
 
 /** Actions available to column filters */
-export type ColumnFilterAction = 'equals' | 'startswith' | 'endswith' | 'contains' | 'length';
+export type ColumnFilterAction = 'equals' | 'startswith' | 'endswith' | 'contains' | 'regex' | 'length';
 
 /** Operands available to column filters */
 export type ColumnFilterOperand = '=' | 'ne' | '<' | '>' | '<=' | '>=' | '[]' | '()';

--- a/frontend/static/filters/StringFilter.tsx
+++ b/frontend/static/filters/StringFilter.tsx
@@ -17,6 +17,7 @@ enum StringFilterAction {
   STARTSWITH = 'startswith',
   ENDSWITH = 'endswith',
   CONTAINS = 'contains',
+  REGEX = 'regex',
   LENGTH = 'length',
 }
 
@@ -70,6 +71,8 @@ export const StringFilter: React.FC<StringFilterProps & WithTranslation> = ({
     const base = t('Press ENTER to submit', { ns: 'correlations' });
     if (action === StringFilterAction.LENGTH) {
       return `${base}. Enter integers for length. For a range enter '1,3' which means '1 <= str.length <= 3'.`;
+    } else if (action === StringFilterAction.REGEX) {
+      return `${base}. Enter Python\'s regular expression understood by re.search().`;
     }
     return base;
   };

--- a/tests/dtale/test_column_filters.py
+++ b/tests/dtale/test_column_filters.py
@@ -85,7 +85,7 @@ def test_string():
 
     with pytest.raises(re.error):
         cfg["raw"] = "["
-        assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 2
+        df.query(build_query(StringFilter("foo", "S", cfg)))
 
     cfg["action"] = "length"
     cfg["raw"] = "3"

--- a/tests/dtale/test_column_filters.py
+++ b/tests/dtale/test_column_filters.py
@@ -1,3 +1,5 @@
+import re
+
 import pandas as pd
 import pytest
 from pkg_resources import parse_version
@@ -67,7 +69,7 @@ def test_string():
     cfg["caseSensitive"] = False
     cfg["raw"] = "\'\""
     assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 1
-    cfg["raw"] = "[\\" # str.contains parses regex
+    cfg["raw"] = "[\\" # don't parse this as regex
     assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 1
 
     cfg["raw"] = "A"
@@ -76,6 +78,14 @@ def test_string():
     assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 4
     cfg["raw"] = "D"
     assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 0
+
+    cfg["action"] = "regex"
+    cfg["raw"] = "[[A].+A$"
+    assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 2
+
+    with pytest.raises(re.error):
+        cfg["raw"] = "["
+        assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 2
 
     cfg["action"] = "length"
     cfg["raw"] = "3"

--- a/tests/dtale/test_column_filters.py
+++ b/tests/dtale/test_column_filters.py
@@ -32,35 +32,48 @@ def test_string():
             return query
         return query.replace("`", "")
 
-    df = pd.DataFrame(dict(foo=["AAA", "aaa", "ABB", "ACC"]))
+    df = pd.DataFrame(dict(foo=["AAA", "aaa", "ABB", "ACC", "\'\"{[\\AA"]))
 
     cfg = dict(action="equals", operand="=", value=["AAA"])
 
     assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 1
     cfg["operand"] = "ne"
-    assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 3
+    assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 4
 
     cfg["value"] = ["AAA", "aaa"]
     cfg["operand"] = "="
     assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 2
+    cfg["value"] = ["\'\"{[\\AA"]
+    assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 1
+    cfg["value"] = ["aaa", "\'\"{[\\AA"]
+    assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 2
+
+    cfg["raw"] = "'"
+    cfg["action"] = "startswith"
+    assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 1
 
     cfg["raw"] = "AA"
     cfg["action"] = "startswith"
     assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 2
     cfg["operand"] = "ne"
-    assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 2
+    assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 3
     cfg["action"] = "endswith"
     cfg["operand"] = "="
-    assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 2
+    assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 3
     cfg["caseSensitive"] = True
-    assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 1
+    assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 2
 
     cfg["action"] = "contains"
     cfg["caseSensitive"] = False
+    cfg["raw"] = "\'\""
+    assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 1
+    cfg["raw"] = "[\\" # str.contains parses regex
+    assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 1
+
     cfg["raw"] = "A"
-    assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 4
+    assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 5
     cfg["caseSensitive"] = True
-    assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 3
+    assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 4
     cfg["raw"] = "D"
     assert len(df.query(build_query(StringFilter("foo", "S", cfg)))) == 0
 


### PR DESCRIPTION
Hi!

Thanks for this great tool!

This PR fixes errors when filtering string-typed columns with values containing special characters, most notably the apostrophe. 
Prior to this PR, it was impossible to filter values like stringified lists: `"['aaa', 'bbb']"`, because `'` was not properly escaped.

While working on this PR, I've noticed a counter-intuitive behavior when filtering with "contains" with query `"["` -- that is, `pandas.Series.str.contains` threats the query as regex by default. In order to prevent introducing a regression for people who depend on this, I've added an explicit "regex" filter type. The errors within regexes are handled as previously.
